### PR TITLE
chore: [PLAT-4154] update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @teamsnap/cse
+* @teamsnap/staffeng-devs


### PR DESCRIPTION
See PLAT-4154

The codeowners file has been updated with guidance from Trey.

If the codeowners file shows as valid, please approve and merge.

If the codeowners file shows as invalid, then we need to update the repository access to include the new codeowners.
